### PR TITLE
Add OSGi Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,10 @@
 <!--
 	Dumbster - a dummy SMTP server
 	Copyright 2016 Joachim Nicolay
-
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.
 	You may obtain a copy of the License at
-
 	http://www.apache.org/licenses/LICENSE-2.0
-
 	Unless required by applicable law or agreed to in writing, software
 	distributed under the License is distributed on an "AS IS" BASIS,
 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +20,7 @@
 	<groupId>com.github.kirviq</groupId>
 	<artifactId>dumbster</artifactId>
 	<version>1.8-SNAPSHOT</version>
+	<packaging>bundle</packaging>
 
 	<name>dumbster</name>
 	<description>a simple fake SMTP server for unit testing</description>
@@ -68,6 +66,12 @@
 					<source>1.7</source>
 					<target>1.7</target>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>3.0.1</version>
+				<extensions>true</extensions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The bnd maven plugin produce OSGi manifest so it can run in an OSGi enviroment.
