### PR TITLE
 Use ConcurrentLinkedQueue (FIFO) instead of ArrayList.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,9 @@ class SomeTest {
 }
 ```
 See more examples in the included [unit tests](https://github.com/kirviq/dumbster/blob/master/src/test/java/com/dumbster/smtp/SimpleSmtpServerTest.java).
+
+### Changelog
+
+- 2018-02-06: Use ConcurrentLinkedQueue (FIFO) instead of ArrayList.
+  This extends current functionality with the possibility to pop (i.e.
+  get and remove) received messages.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ See more examples in the included [unit tests](https://github.com/kirviq/dumbste
 
 ### Changelog
 
-- 2018-02-06: Use ConcurrentLinkedQueue (FIFO) instead of ArrayList.
-  This extends current functionality with the possibility to pop (i.e.
-  get and remove) received messages.
+- 2018-02-06
+  - Use ConcurrentLinkedQueue (FIFO) instead of ArrayList. This extends
+    current functionality with the possibility to pop (i.e. get and
+    remove) received messages.
+  - JRE 8 is required for tests

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.5.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
 	<groupId>com.github.kirviq</groupId>
 	<artifactId>dumbster</artifactId>
-	<version>1.8-SNAPSHOT</version>
+	<version>1.9-SNAPSHOT</version>
 
 	<name>dumbster</name>
 	<description>a simple fake SMTP server for unit testing</description>

--- a/src/main/java/com/dumbster/smtp/SimpleSmtpServer.java
+++ b/src/main/java/com/dumbster/smtp/SimpleSmtpServer.java
@@ -89,20 +89,19 @@ public final class SimpleSmtpServer implements AutoCloseable {
 	}
 
     /**
+     * @return the port the server is listening on
+     */
+    public int getPort() {
+        return serverSocket.getLocalPort();
+    }
+
+    /**
      * All received email stored in a thread-safe queue
      * @return all received email stored in a thread-safe queue
      */
     public Queue<SmtpMessage> getReceivedEmails() {
         return receivedEmails;
     }
-
-    /**
-	 * @return the port the server is listening on
-	 */
-	public int getPort() {
-		return serverSocket.getLocalPort();
-	}
-
 
 	/**
 	 * Stops the server. Server is shutdown after processing of the current request is complete.

--- a/src/main/java/com/dumbster/smtp/SimpleSmtpServer.java
+++ b/src/main/java/com/dumbster/smtp/SimpleSmtpServer.java
@@ -45,7 +45,10 @@ public final class SimpleSmtpServer implements AutoCloseable {
 
 	private static final Pattern CRLF = Pattern.compile("\r\n");
 
-    /** Stores all of the email received since this instance started up. */
+    /**
+     * Store and offer received emails with a {@link Queue}.
+     * Implementation uses a unbounded and thread-safe {@link ConcurrentLinkedQueue}
+     */
 	private final Queue<SmtpMessage> receivedMail = new ConcurrentLinkedQueue<>();
 
 	/** The server socket this server listens to. */

--- a/src/main/java/com/dumbster/smtp/SimpleSmtpServer.java
+++ b/src/main/java/com/dumbster/smtp/SimpleSmtpServer.java
@@ -49,7 +49,7 @@ public final class SimpleSmtpServer implements AutoCloseable {
      * Store and offer received emails in a {@link Queue} object.
      * Implementation uses a unbounded and thread-safe {@link ConcurrentLinkedQueue}
      */
-	private final Queue<SmtpMessage> receivedMail = new ConcurrentLinkedQueue<>();
+	private final Queue<SmtpMessage> receivedEmails = new ConcurrentLinkedQueue<>();
 
 	/** The server socket this server listens to. */
 	private final ServerSocket serverSocket;
@@ -92,8 +92,8 @@ public final class SimpleSmtpServer implements AutoCloseable {
      * All received email stored in a thread-safe queue
      * @return all received email stored in a thread-safe queue
      */
-    public Queue<SmtpMessage> getReceivedMail() {
-        return receivedMail;
+    public Queue<SmtpMessage> getReceivedEmails() {
+        return receivedEmails;
     }
 
     /**
@@ -152,7 +152,7 @@ public final class SimpleSmtpServer implements AutoCloseable {
 						 * We synchronize over the handle method and the list update because the client call completes inside
 						 * the handle method and we have to prevent the client from reading the list until we've updated it.
 						 */
-						receivedMail.addAll(handleTransaction(out, input));
+						receivedEmails.addAll(handleTransaction(out, input));
 
 				}
 			}

--- a/src/main/java/com/dumbster/smtp/SimpleSmtpServer.java
+++ b/src/main/java/com/dumbster/smtp/SimpleSmtpServer.java
@@ -169,7 +169,7 @@ public final class SimpleSmtpServer implements AutoCloseable {
                     synchronized (receivedEmails) {
 						/*
 						 * We synchronize over the handle method and the queue update because the client call completes inside
-						 * the handle method and we should to prevent the client from reading the list until we've updated it.
+						 * the handle method and we should prevent the client from reading the list until we've updated it.
 						 */
                         receivedEmails.addAll(handleTransaction(out, input));
                     }

--- a/src/main/java/com/dumbster/smtp/SimpleSmtpServer.java
+++ b/src/main/java/com/dumbster/smtp/SimpleSmtpServer.java
@@ -46,7 +46,7 @@ public final class SimpleSmtpServer implements AutoCloseable {
 	private static final Pattern CRLF = Pattern.compile("\r\n");
 
     /**
-     * Store and offer received emails with a {@link Queue}.
+     * Store and offer received emails in a {@link Queue} object.
      * Implementation uses a unbounded and thread-safe {@link ConcurrentLinkedQueue}
      */
 	private final Queue<SmtpMessage> receivedMail = new ConcurrentLinkedQueue<>();

--- a/src/main/java/com/dumbster/smtp/SmtpMessage.java
+++ b/src/main/java/com/dumbster/smtp/SmtpMessage.java
@@ -17,13 +17,7 @@
  */
 package com.dumbster.smtp;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Container for a complete SMTP message - headers and message body.
@@ -40,26 +34,26 @@ public class SmtpMessage {
 		body = new StringBuilder();
 	}
 
-	/**
-	 * Update the headers or body depending on the SmtpResponse object and line of input.
-	 *
-	 * @param response SmtpResponse object
-	 * @param params   remainder of input line after SMTP command has been removed
-	 */
-	public void store(SmtpResponse response, String params) {
-		if (params != null) {
-			if (SmtpState.DATA_HDR.equals(response.getNextState())) {
-				int headerNameEnd = params.indexOf(':');
-				if (headerNameEnd >= 0) {
-					String name = params.substring(0, headerNameEnd).trim();
-					String value = params.substring(headerNameEnd + 1).trim();
-					addHeader(name, value);
-				}
-			} else if (SmtpState.DATA_BODY == response.getNextState()) {
-				body.append(params);
-			}
-		}
-	}
+    /**
+     * Update the headers or body depending on the SmtpResponse object and line of input.
+     *
+     * @param response SmtpResponse object
+     * @param params   remainder of input line after SMTP command has been removed
+     */
+    public void store(SmtpResponse response, String params) {
+        if (params != null) {
+            if (SmtpState.DATA_HDR.equals(response.getNextState())) {
+                int headerNameEnd = params.indexOf(':');
+                if (headerNameEnd >= 0) {
+                    String name = params.substring(0, headerNameEnd).trim();
+                    String value = params.substring(headerNameEnd + 1).trim();
+                    addHeader(name, value);
+                }
+            } else if (SmtpState.DATA_BODY == response.getNextState()) {
+                body.append(params);
+            }
+        }
+    }
 
 	/**
 	 * Get an Iterator over the header names.

--- a/src/main/java/com/dumbster/smtp/SmtpMessage.java
+++ b/src/main/java/com/dumbster/smtp/SmtpMessage.java
@@ -17,7 +17,13 @@
  */
 package com.dumbster.smtp;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Container for a complete SMTP message - headers and message body.

--- a/src/main/java/com/dumbster/smtp/SmtpMessage.java
+++ b/src/main/java/com/dumbster/smtp/SmtpMessage.java
@@ -40,26 +40,26 @@ public class SmtpMessage {
 		body = new StringBuilder();
 	}
 
-    /**
-     * Update the headers or body depending on the SmtpResponse object and line of input.
-     *
-     * @param response SmtpResponse object
-     * @param params   remainder of input line after SMTP command has been removed
-     */
-    public void store(SmtpResponse response, String params) {
-        if (params != null) {
-            if (SmtpState.DATA_HDR.equals(response.getNextState())) {
-                int headerNameEnd = params.indexOf(':');
-                if (headerNameEnd >= 0) {
-                    String name = params.substring(0, headerNameEnd).trim();
-                    String value = params.substring(headerNameEnd + 1).trim();
-                    addHeader(name, value);
-                }
-            } else if (SmtpState.DATA_BODY == response.getNextState()) {
-                body.append(params);
-            }
-        }
-    }
+	/**
+	 * Update the headers or body depending on the SmtpResponse object and line of input.
+	 *
+	 * @param response SmtpResponse object
+	 * @param params   remainder of input line after SMTP command has been removed
+	 */
+	public void store(SmtpResponse response, String params) {
+		if (params != null) {
+			if (SmtpState.DATA_HDR.equals(response.getNextState())) {
+				int headerNameEnd = params.indexOf(':');
+				if (headerNameEnd >= 0) {
+					String name = params.substring(0, headerNameEnd).trim();
+					String value = params.substring(headerNameEnd + 1).trim();
+					addHeader(name, value);
+				}
+			} else if (SmtpState.DATA_BODY == response.getNextState()) {
+				body.append(params);
+			}
+		}
+	}
 
 	/**
 	 * Get an Iterator over the header names.

--- a/src/test/java/com/dumbster/smtp/SimpleSmtpServerTest.java
+++ b/src/test/java/com/dumbster/smtp/SimpleSmtpServerTest.java
@@ -62,6 +62,67 @@ public class SimpleSmtpServerTest {
     }
 
     @Test
+    public void testPerformanceSingleThread() throws MessagingException {
+        System.out.println("testPerformanceSingleThread");
+        long t1 = System.currentTimeMillis();
+        int loops = 10;
+        int inLoopCount = 1000;
+        for (int l = 1; l <= loops; l++) {
+            for (int i = 0; i < inLoopCount; i++) {
+                sendMessage(server.getPort(), "sender@here.com", "Test " + i, "Test Body", "receiver@there.com");
+            }
+            long t2 = System.currentTimeMillis();
+            int total = (int) ((t2-t1)/1000);
+            int avg = inLoopCount*l / total;
+            System.out.println("added " + inLoopCount*l + " emails in " + total + " seconds => " + avg + " emails/s");
+        }
+        assertThat(server.getReceivedEmails(), hasSize(inLoopCount*loops));
+
+        long t3 = System.currentTimeMillis();
+        for (int i = 0; i < inLoopCount*loops; i++) {
+            server.getReceivedEmails().poll();
+        }
+        long t4 = System.currentTimeMillis();
+        int total2 = (int) ((t4-t3==0?1:t4-t3));
+        int avg2 = inLoopCount*loops / total2;
+        System.out.println("polled " + inLoopCount*loops + " emails in " + total2 + " ms => " + avg2 + " emails/ms");
+        assertThat(server.getReceivedEmails(), hasSize(0));
+    }
+
+    @Test
+    public void testPerformanceParallel() throws MessagingException {
+        System.out.println("testPerformanceParallel");
+        final int inLoopCount = 10000;
+        List<Integer> numbers = new ArrayList<Integer>(inLoopCount);
+        for (int i = 0; i < inLoopCount; i++) {
+            numbers.add(i);
+        }
+        long t1 = System.currentTimeMillis();
+        numbers.stream().parallel().forEach(i -> {
+            try {
+                sendMessage(server.getPort(), "sender@here.com", "Test " + i, "Test Body", "receiver@there.com");
+            } catch (MessagingException e) {
+                e.printStackTrace();
+            }
+        });
+        long t2 = System.currentTimeMillis();
+        int total = (int) ((t2-t1)/1000);
+        int avg = inLoopCount / total;
+        System.out.println("added " + inLoopCount + " emails in " + total + " seconds => " + avg + " emails/s");
+        assertThat(server.getReceivedEmails(), hasSize(inLoopCount));
+
+        long t3 = System.currentTimeMillis();
+        for (int i = 0; i < inLoopCount; i++) {
+            server.getReceivedEmails().poll();
+        }
+        long t4 = System.currentTimeMillis();
+        int total2 = (int) ((t4-t3==0?1:t4-t3));
+        int avg2 = inLoopCount / total2;
+        System.out.println("polled " + inLoopCount + " emails in " + total2 + " ms => " + avg2 + " emails/ms");
+        assertThat(server.getReceivedEmails(), hasSize(0));
+    }
+
+    @Test
     public void testGetReceivedEmailCopy() throws MessagingException {
         sendMessage(server.getPort(), "sender@here.com", "Test", "Test Body", "receiver@there.com");
         List<SmtpMessage> receivedEmailCopy = server.getReceivedEmailCopy();

--- a/src/test/java/com/dumbster/smtp/SimpleSmtpServerTest.java
+++ b/src/test/java/com/dumbster/smtp/SimpleSmtpServerTest.java
@@ -55,9 +55,8 @@ public class SimpleSmtpServerTest {
 	public void testSend() throws MessagingException {
 		sendMessage(server.getPort(), "sender@here.com", "Test", "Test Body", "receiver@there.com");
 
-		List<SmtpMessage> emails = server.getReceivedEmails();
-		assertThat(emails, hasSize(1));
-		SmtpMessage email = emails.get(0);
+		assertThat(server.getReceivedMail(), hasSize(1));
+		SmtpMessage email = server.getReceivedMail().poll();
 		assertThat(email.getHeaderValue("Subject"), is("Test"));
 		assertThat(email.getBody(), is("Test Body"));
 		assertThat(email.getHeaderNames(), hasItem("Date"));
@@ -71,13 +70,13 @@ public class SimpleSmtpServerTest {
 	@Test
 	public void testSendAndReset() throws MessagingException {
 		sendMessage(server.getPort(), "sender@here.com", "Test", "Test Body", "receiver@there.com");
-		assertThat(server.getReceivedEmails(), hasSize(1));
+		assertThat(server.getReceivedMail(), hasSize(1));
 
-		server.reset();
-		assertThat(server.getReceivedEmails(), hasSize(0));
+		server.getReceivedMail().clear();
+		assertThat(server.getReceivedMail(), hasSize(0));
 
 		sendMessage(server.getPort(), "sender@here.com", "Test", "Test Body", "receiver@there.com");
-		assertThat(server.getReceivedEmails(), hasSize(1));
+		assertThat(server.getReceivedMail(), hasSize(1));
 	}
 
 	@Test
@@ -85,9 +84,8 @@ public class SimpleSmtpServerTest {
 		String bodyWithCR = "\n\nKeep these pesky carriage returns\n\n";
 		sendMessage(server.getPort(), "sender@hereagain.com", "CRTest", bodyWithCR, "receivingagain@there.com");
 
-		List<SmtpMessage> emails = server.getReceivedEmails();
-		assertThat(emails, hasSize(1));
-		SmtpMessage email = emails.get(0);
+		assertThat(server.getReceivedMail(), hasSize(1));
+		SmtpMessage email = server.getReceivedMail().poll();
 		assertEquals(bodyWithCR, email.getBody());
 	}
 
@@ -110,7 +108,7 @@ public class SimpleSmtpServerTest {
 
 		transport.close();
 
-		assertThat(server.getReceivedEmails(), hasSize(2));
+		assertThat(server.getReceivedMail(), hasSize(2));
 	}
 
 	@Test
@@ -158,9 +156,8 @@ public class SimpleSmtpServerTest {
 			}
 		}
 
-		List<SmtpMessage> emails = this.server.getReceivedEmails();
-		assertThat(emails, hasSize(2));
-		SmtpMessage email = emails.get(0);
+		assertThat(server.getReceivedMail(), hasSize(2));
+		SmtpMessage email = server.getReceivedMail().poll();
 		assertTrue(email.getHeaderValue("Subject").equals("Test"));
 		assertTrue(email.getBody().equals("Test Body"));
 	}

--- a/src/test/java/com/dumbster/smtp/SimpleSmtpServerTest.java
+++ b/src/test/java/com/dumbster/smtp/SimpleSmtpServerTest.java
@@ -85,7 +85,7 @@ public class SimpleSmtpServerTest {
 		sendMessage(server.getPort(), "sender@here.com", "Test", "Test Body", "receiver@there.com");
 		assertThat(server.getReceivedEmails(), hasSize(1));
 
-		server.getReceivedEmails().clear();
+		server.reset();
 		assertThat(server.getReceivedEmails(), hasSize(0));
 
 		sendMessage(server.getPort(), "sender@here.com", "Test", "Test Body", "receiver@there.com");

--- a/src/test/java/com/dumbster/smtp/SimpleSmtpServerTest.java
+++ b/src/test/java/com/dumbster/smtp/SimpleSmtpServerTest.java
@@ -55,8 +55,8 @@ public class SimpleSmtpServerTest {
 	public void testSend() throws MessagingException {
 		sendMessage(server.getPort(), "sender@here.com", "Test", "Test Body", "receiver@there.com");
 
-		assertThat(server.getReceivedMail(), hasSize(1));
-		SmtpMessage email = server.getReceivedMail().poll();
+		assertThat(server.getReceivedEmails(), hasSize(1));
+		SmtpMessage email = server.getReceivedEmails().poll();
 		assertThat(email.getHeaderValue("Subject"), is("Test"));
 		assertThat(email.getBody(), is("Test Body"));
 		assertThat(email.getHeaderNames(), hasItem("Date"));
@@ -70,13 +70,13 @@ public class SimpleSmtpServerTest {
 	@Test
 	public void testSendAndReset() throws MessagingException {
 		sendMessage(server.getPort(), "sender@here.com", "Test", "Test Body", "receiver@there.com");
-		assertThat(server.getReceivedMail(), hasSize(1));
+		assertThat(server.getReceivedEmails(), hasSize(1));
 
-		server.getReceivedMail().clear();
-		assertThat(server.getReceivedMail(), hasSize(0));
+		server.getReceivedEmails().clear();
+		assertThat(server.getReceivedEmails(), hasSize(0));
 
 		sendMessage(server.getPort(), "sender@here.com", "Test", "Test Body", "receiver@there.com");
-		assertThat(server.getReceivedMail(), hasSize(1));
+		assertThat(server.getReceivedEmails(), hasSize(1));
 	}
 
 	@Test
@@ -84,8 +84,8 @@ public class SimpleSmtpServerTest {
 		String bodyWithCR = "\n\nKeep these pesky carriage returns\n\n";
 		sendMessage(server.getPort(), "sender@hereagain.com", "CRTest", bodyWithCR, "receivingagain@there.com");
 
-		assertThat(server.getReceivedMail(), hasSize(1));
-		SmtpMessage email = server.getReceivedMail().poll();
+		assertThat(server.getReceivedEmails(), hasSize(1));
+		SmtpMessage email = server.getReceivedEmails().poll();
 		assertEquals(bodyWithCR, email.getBody());
 	}
 
@@ -108,7 +108,7 @@ public class SimpleSmtpServerTest {
 
 		transport.close();
 
-		assertThat(server.getReceivedMail(), hasSize(2));
+		assertThat(server.getReceivedEmails(), hasSize(2));
 	}
 
 	@Test
@@ -156,8 +156,8 @@ public class SimpleSmtpServerTest {
 			}
 		}
 
-		assertThat(server.getReceivedMail(), hasSize(2));
-		SmtpMessage email = server.getReceivedMail().poll();
+		assertThat(server.getReceivedEmails(), hasSize(2));
+		SmtpMessage email = server.getReceivedEmails().poll();
 		assertTrue(email.getHeaderValue("Subject").equals("Test"));
 		assertTrue(email.getBody().equals("Test Body"));
 	}

--- a/src/test/java/com/dumbster/smtp/SimpleSmtpServerTest.java
+++ b/src/test/java/com/dumbster/smtp/SimpleSmtpServerTest.java
@@ -29,10 +29,7 @@ import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 import java.util.*;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -51,8 +48,21 @@ public class SimpleSmtpServerTest {
 		server.stop();
 	}
 
-	@Test
-	public void testGetReceivedEmailCopy() throws MessagingException {
+    @Test
+    public void testPoll() throws MessagingException {
+        sendMessage(server.getPort(), "sender@here.com", "Test 1", "Test Body", "receiver@there.com");
+        sendMessage(server.getPort(), "sender@here.com", "Test 2", "Test Body", "receiver@there.com");
+        assertThat(server.getReceivedEmails(), hasSize(2));
+        SmtpMessage smtpMessage1 = server.getReceivedEmails().poll();
+        assertThat(smtpMessage1.getHeaderValue("Subject"), isOneOf("Test 1"));
+        assertThat(server.getReceivedEmails(), hasSize(1));
+        SmtpMessage smtpMessage2 = server.getReceivedEmails().poll();
+        assertThat(smtpMessage2.getHeaderValue("Subject"), isOneOf("Test 2"));
+        assertThat(server.getReceivedEmails(), hasSize(0));
+    }
+
+    @Test
+    public void testGetReceivedEmailCopy() throws MessagingException {
         sendMessage(server.getPort(), "sender@here.com", "Test", "Test Body", "receiver@there.com");
         List<SmtpMessage> receivedEmailCopy = server.getReceivedEmailCopy();
         assertThat(receivedEmailCopy, hasSize(1));
@@ -64,7 +74,7 @@ public class SimpleSmtpServerTest {
         assertThat(server.getReceivedEmails(), hasSize(0));
     }
 
-	@Test
+    @Test
 	public void testSend() throws MessagingException {
 		sendMessage(server.getPort(), "sender@here.com", "Test", "Test Body", "receiver@there.com");
 

--- a/src/test/java/com/dumbster/smtp/SimpleSmtpServerTest.java
+++ b/src/test/java/com/dumbster/smtp/SimpleSmtpServerTest.java
@@ -52,6 +52,19 @@ public class SimpleSmtpServerTest {
 	}
 
 	@Test
+	public void testGetReceivedEmailCopy() throws MessagingException {
+        sendMessage(server.getPort(), "sender@here.com", "Test", "Test Body", "receiver@there.com");
+        List<SmtpMessage> receivedEmailCopy = server.getReceivedEmailCopy();
+        assertThat(receivedEmailCopy, hasSize(1));
+        receivedEmailCopy.clear();
+        assertThat(receivedEmailCopy, hasSize(0));
+        assertThat(server.getReceivedEmailCopy(), hasSize(1));
+        server.getReceivedEmails().clear();
+        assertThat(server.getReceivedEmailCopy(), hasSize(0));
+        assertThat(server.getReceivedEmails(), hasSize(0));
+    }
+
+	@Test
 	public void testSend() throws MessagingException {
 		sendMessage(server.getPort(), "sender@here.com", "Test", "Test Body", "receiver@there.com");
 


### PR DESCRIPTION
Use a unbounded FIFO Queue object (ConcurrentLinkedQueue) as backing data structure instead of ArrayList. This extends the current functionality with the possibility to pop/poll (i.e. get and remove) single received messages. Before, one could only clear all messages.
The Queue Interface is more or less a superset of the List interface, so existing code can be adapted very easily.